### PR TITLE
initial 0.13.10

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/aws-c-cal-feedstock/pr1/ea61a89
+  - https://staging.continuum.io/prefect/fs/s2n-feedstock/pr1/ade4da2
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.14.2" %}
+{% set version = "0.13.10" %}
 
 package:
   name: aws-c-io
@@ -6,10 +6,11 @@ package:
 
 source:
   url: https://github.com/awslabs/aws-c-io/archive/v{{ version }}.tar.gz
-  sha256: 791ca7168aba93885e69343612fd13356c7fe11dff04f6b774136d8d4aed6b6a
+  sha256: 4e7caa335ece916c00f4c9896e7413bb6ed52abc77e2c3dda3ffe5bcf3fc8655
 
 build:
-  number: 1
+  number: 0
+  skip: True
   run_exports:
     - {{ pin_subpackage("aws-c-io", max_pin="x.x.x") }}
 
@@ -17,11 +18,11 @@ requirements:
   build:
     - cmake !=3.19.0,!=3.19.1
     - {{ compiler('c') }}
-    - ninja
+    - ninja-base
   host:
-    - aws-c-common
-    - aws-c-cal
-    - s2n  # [linux]
+    - aws-c-common 0.8.5
+    - aws-c-cal 0.5.20
+    - s2n 1.3.27 # [linux]
 
 test:
   commands:


### PR DESCRIPTION
aws-c-io 0.13.10

Destination channel: defaults

Links
[ticket_number](https://anaconda.atlassian.net/browse/PKG-3944)
[Upstream repository](https://github.com/awslabs/aws-c-io/tree/v0.13.10)
dependency for  aws-c-event-stream 0.2.15 -> aws-sdk-cpp 1.10.55 -> arrow-cpp 14.0.1 -> pyarrow 14.0.1 which would address CVE
